### PR TITLE
Transient stress analysis for vertical channels

### DIFF
--- a/bamboo/cooling.py
+++ b/bamboo/cooling.py
@@ -496,7 +496,7 @@ class CoolingJacket:
         custom_effective_diameter (float, optional): If using channel_shape = 'custom', this is the effective diameter you want to use. 
         custom_flow_area (float, optional): If using channel_shape = 'custom', this is the flow you want to use.
     """
-    def __init__(self, geometry, inner_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", has_ablator = False, **kwargs):
+    def __init__(self, geometry, inner_wall, outer_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", has_ablator = False, **kwargs):
 
         self.ymax = geometry.chamber_radius
         self.inner_wall = inner_wall

--- a/bamboo/cooling.py
+++ b/bamboo/cooling.py
@@ -496,7 +496,7 @@ class CoolingJacket:
         custom_effective_diameter (float, optional): If using channel_shape = 'custom', this is the effective diameter you want to use. 
         custom_flow_area (float, optional): If using channel_shape = 'custom', this is the flow you want to use.
     """
-    def __init__(self, geometry, inner_wall, outer_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", has_ablator = False, **kwargs):
+    def __init__(self, geometry, inner_wall, outer_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", has_ablative = False, **kwargs):
 
         self.ymax = geometry.chamber_radius
         self.inner_wall = inner_wall
@@ -507,7 +507,7 @@ class CoolingJacket:
         self.inlet_T = inlet_T
         self.inlet_p0 = inlet_p0
         self.configuration = configuration
-        self.has_ablator = has_ablator
+        self.has_ablative = has_ablative
         
         if self.configuration == 'spiral':
             self.channel_shape = kwargs['channel_shape']
@@ -554,7 +554,7 @@ class CoolingJacket:
             return self.flow_area
 
         elif self.configuration == 'vertical':
-            if self.has_ablator is True:
+            if self.has_ablative is True:
                 y = self.ymax
             # Ignore the nozzle contours - jacket has constant radius if an ablative insert is present
             return np.pi*((y + self.channel_height)**2 - y**2) * (1 - self.blockage_ratio)
@@ -572,7 +572,7 @@ class CoolingJacket:
         Returns:
             float: Effective diameter (m)
         """
-        if self.has_ablator is True:
+        if self.has_ablative is True:
             y = self.ymax
         # Ignore the nozzle contours - jacket has constant radius if an ablative insert is present
         

--- a/bamboo/cooling.py
+++ b/bamboo/cooling.py
@@ -480,6 +480,7 @@ class CoolingJacket:
 
     Args:
         inner_wall (Material): Wall material on the inner side of the cooling jacket.
+        outer_wall (Material): Wall material for the outer liner. 
         inlet_T (float): Inlet coolant temperature (K)
         inlet_p0 (float): Inlet coolant stagnation pressure (Pa)
         coolant_transport (TransportProperties): Container for the coolant transport properties.
@@ -494,12 +495,12 @@ class CoolingJacket:
         channel_width (float, optional): If using channel_shape = 'rectangle', this is the width of the channels (m). If using channel_shape = 'semi-circle', this is the diameter of the semi circle (m).
         custom_effective_diameter (float, optional): If using channel_shape = 'custom', this is the effective diameter you want to use. 
         custom_flow_area (float, optional): If using channel_shape = 'custom', this is the flow you want to use.
-        outer_wall (Material, optional): Wall material for the outer liner. Only needed for transient stress analysis. 
     """
     def __init__(self, geometry, inner_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", has_ablator = False, **kwargs):
 
         self.ymax = geometry.chamber_radius
         self.inner_wall = inner_wall
+        self.outer_wall = outer_wall
         self.coolant_transport = coolant_transport       
         self.mdot_coolant = mdot_coolant
         self.xs = xs
@@ -508,9 +509,6 @@ class CoolingJacket:
         self.configuration = configuration
         self.has_ablator = has_ablator
         
-        if "outer_wall" in kwargs:
-            self.outer_wall = kwargs["outer_wall"]
-
         if self.configuration == 'spiral':
             self.channel_shape = kwargs['channel_shape']
 

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -520,9 +520,8 @@ class EngineGeometry:
         chamber_length (float): Length of the combustion chamber (m)
         chamber_area (float): Cross sectional area of the combustion chamber (m^2)
         inner_wall_thickness (float or array): Thickness of the inner liner wall (m). Can be constant (float), or variable (array). 
-        style (str, optional): Geometry style to use. Currently the only option is 'auto'. Defaults to "auto".
         outer_wall_thickness (float or array): Thickness of the outer liner wall (m). Can be constant (float), or variable (array).
-                                               Used for transient stress analysis, the CoolingJacket needs an outer liner material.
+        style (str, optional): Geometry style to use. Currently the only option is 'auto'. Defaults to "auto".
 
     Attributes:
         x_min (float): Minimum x position (m).
@@ -1114,14 +1113,15 @@ class Engine:
 
 
         self.geometry = EngineGeometry(self.nozzle, chamber_length, chamber_area, inner_wall_thickness,
-                                       style, outer_wall_thickness)
+                                       outer_wall_thickness, style)
         self.has_geometry = True
 
-    def add_cooling_jacket(self, inner_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", **kwargs):
+    def add_cooling_jacket(self, inner_wall, outer_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", **kwargs):
         """Container for cooling jacket information - e.g. for regenerative cooling.
 
         Args:
-            inner_wall (Material): Inner wall material
+            inner_wall (Material): Inner wall material.
+            outer_wall (Material): Wall material for the outer liner. 
             inlet_T (float): Inlet coolant temperature (K)
             inlet_p0 (float): Inlet coolant stagnation pressure (Pa)
             coolant_transport (TransportProperties): Container for the coolant transport properties.
@@ -1138,7 +1138,8 @@ class Engine:
         """
         
         self.cooling_jacket = cool.CoolingJacket(self.geometry,
-                                                inner_wall, 
+                                                inner_wall,
+                                                outer_wall, 
                                                 inlet_T, 
                                                 inlet_p0, 
                                                 coolant_transport, 
@@ -1906,7 +1907,7 @@ class Engine:
         return output_dict
 
 
-    def run_stress_analysis(self, heating_result, type="thermal", condition="steady"):
+    def run_stress_analysis(self, heating_result, mode="thermal", condition="steady", **kwargs):
         """Perform stress analysis on the liner, using a cooling result.
         Args:
             heating_result (dict): Requires a heating analysis result to compute stress.

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -2031,33 +2031,38 @@ class Engine:
                 # the ribs occupy part of the wall area, and their contribution
                 # to the stress has already been accounted for above.
 
-                # Array for the pressure inside the engine along its length.
-                discretised_x = np.linspace(self.geometry.x_max, self.geometry.x_min, length)
-                engine_pressure = [self.p(discretised_x[i]) for i in range(length)]
+                # In phase I, when the engine has not yet been ignited but there is
+                # pressurised IPA in the cooling jacket, the internal pressure is 0
+                # (technically 0 gauge, but ambient is neglected)
+                sigma_inner_hoop_I = np.array(heating_result["p_coolant"]) * R1_hoop/t1_hoop
 
-                sigma_inner_hoop = (np.array(heating_result["p_coolant"]) - \
-                                    engine_pressure) * R1_hoop/t1_hoop
+                # Array for the pressure inside the engine along its length, after ignition.
+                discretised_x = np.linspace(self.geometry.x_max, self.geometry.x_min, length)
+                engine_pressure_II = [self.p(discretised_x[i]) for i in range(length)]
+                sigma_inner_hoop_II = (np.array(heating_result["p_coolant"]) - \
+                                    engine_pressure_II) * R1_hoop/t1_hoop
 
                 # Ambient pressure is neglected
-                sigma_outer_hoop = np.array(heating_result["p_coolant"])*R2/t2
+                sigma_outer_hoop_II = np.array(heating_result["p_coolant"])*R2/t2
 
                 #sigma_inner = sigma_inner_hoop + sigma_inner_IE
                 #sigma_outer = sigma_outer_hoop + sigma_outer_IE
 
                 # Quick graphs
-                #print(min(sigma_inner)/1E6)
-                #print(max(sigma_outer)/1E6)
-                #print(list(sigma_inner).index(min(sigma_inner))*(self.geometry.x_max-self.geometry.x_min)/length)
-                plt.title("Engine start-up stresses due to inner liner expansion and pressure differences")
-                plt.plot(np.abs(sigma_inner_hoop[::-1]/1E6), label="$|\sigma_{inner}|$")
-                plt.plot(np.abs(sigma_outer_hoop[::-1]/1E6), label="$|\sigma_{outer}|$")
+                #plt.title("Engine start-up stresses due to inner liner expansion and pressure differences")
+                plt.title("Liner stresses (phase II / prior to thermal equlibrium)")
+                plt.plot(np.abs(sigma_inner_hoop_II[::-1]/1E6), label="$|\sigma_{inner}| (hoop)$")
+                plt.plot(np.abs(sigma_outer_hoop_II[::-1]/1E6), label="$|\sigma_{outer}| (hoop)$")
+                plt.plot(np.abs(sigma_outer_IE[::-1]/1E6), label="$|\sigma_{outer}| (IE)$")
+                plt.plot(np.abs(sigma_inner_IE[::-1]/1E6), label="$|\sigma_{inner}| (IE)$")
+                #plt.plot(np.abs(sigma_outer_hoop_II[::-1]/1E6), label="$|\sigma_{outer}|$")
                 plt.xlabel(f"Axial position index (Nozzle exit = {length}, injector head = 0)")
                 plt.ylabel("Stress $MPa$")
                 plt.legend()
                 plt.show()
 
-                return {"stress_inner_hoop": sigma_inner_hoop,
-                        "stress_outer_hoop": sigma_outer_hoop,
+                return {"stress_inner_hoop_II": sigma_inner_hoop_II,
+                        "stress_outer_hoop_II": sigma_outer_hoop_II,
                         "stress_inner_IE": sigma_inner_IE,
                         "stress_outer_IE": sigma_outer_IE}
 

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -1970,11 +1970,6 @@ class Engine:
                     heating_result["T_wall_outer"][i]
                 tadjusted_yield[i] = mat_in.relStrength(heating_result["T_wall_inner"][i]) * mat_in.sigma_y
 
-            # Compute wall temperature gradient
-            wall_deltaT = wall_deltaT[::-1]
-            # Makes the data order match with the coolant flow direction, i.e. nozzle exit to
-            # injector face. Spent an hour wondering why the throat was cooler than the chamber wall...
-
             for i in range(length):
                 cur_stress = mat_in.k * \
                     wall_deltaT[i] / (2 * mat_in.perf_therm)

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -2035,13 +2035,10 @@ class Engine:
                 discretised_x = np.linspace(self.geometry.x_max, self.geometry.x_min, length)
                 engine_pressure = [self.p(discretised_x[i]) for i in range(length)]
 
+                sigma_inner_hoop = (np.array(heating_result["p_coolant"]) - \
+                                    engine_pressure) * R1_hoop/t1_hoop
 
-                sigma_inner_hoop = (np.array(heating_result["p_coolant"]) - self.chamber_conditions.p0) \
-                                    *R1_hoop/t1_hoop
-                # Need to account for the falling pressure in the nozzle ideally else
-                # this will underestimate the stress in the nozzle as the flow expands.
-
-                # Assume ambient pressure of 1 bar
+                # Ambient pressure is neglected
                 sigma_outer_hoop = np.array(heating_result["p_coolant"])*R2/t2
 
                 #sigma_inner = sigma_inner_hoop + sigma_inner_IE

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -1909,13 +1909,11 @@ class Engine:
 
     def run_stress_analysis(self, heating_result, condition="steady", **kwargs):
         """Perform stress analysis on the liner, using a cooling result.
-           Things this function does not account for:
-                - Transient stress due to temperature differences across the inner liner.
-                - Stresses in the axial direction due to axial temperature gradients
+           Results should be taken only as a first approximation of some key stresses.
+
         Args:
             heating_result (dict): Requires a heating analysis result to compute stress.
-            mode (str, optional): Options are "pressure",  "thermal" and "combined". Defaults to "thermal". (ONLY DEFAULT WORKS)
-            condition (str, optional): Engine state for analysis. Options are "steady", or "transient". Defaults to "steady". (ONLY DEFAULT WORKS)
+            condition (str, optional): Engine state for analysis. Options are "steady", or "transient". Defaults to "steady".
 
         Keyword Args:
             T_amb (float, optional): For transient analysis, the ambient temperature can be overriden from the default, 283 K.
@@ -2052,19 +2050,6 @@ class Engine:
                 engine_pressure = [self.p(discretised_x[i]) for i in range(length)]
                 sigma_inner_hoop = (np.array(heating_result["p_coolant"]) - \
                                     engine_pressure) * R1_hoop/t1_hoop
-
-                """# Quick graphs
-                #plt.title("Engine start-up stresses due to inner liner expansion and pressure differences")
-                plt.title("Liner stresses (phase II / prior to thermal equlibrium)")
-                plt.plot(np.abs(sigma_inner_hoop_II[::-1]/1E6), label="$|\sigma_{inner}| (hoop)$")
-                plt.plot(np.abs(sigma_outer_hoop[::-1]/1E6), label="$|\sigma_{outer}| (hoop)$")
-                plt.plot(np.abs(sigma_outer_IE[::-1]/1E6), label="$|\sigma_{outer}| (IE)$")
-                plt.plot(np.abs(sigma_inner_IE[::-1]/1E6), label="$|\sigma_{inner}| (IE)$")
-                #plt.plot(np.abs(sigma_outer_hoop_II[::-1]/1E6), label="$|\sigma_{outer}|$")
-                plt.xlabel(f"Axial position index (Nozzle exit = {length}, injector head = 0)")
-                plt.ylabel("Stress $MPa$")
-                plt.legend()
-                plt.show()"""
 
                 return {"stress_inner_hoop_transient": sigma_inner_hoop,
                         "stress_inner_IE": sigma_inner_IE,

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -1947,16 +1947,16 @@ class Engine:
             for i in range(length):
                 wall_deltaT[i] = heating_result["T_wall_inner"][i] - \
                     heating_result["T_wall_outer"][i]
-            tadjusted_yield[i] = material.relStrength(heating_result["T_wall_inner"][i]) * material.sigma_y
+                tadjusted_yield[i] = mat_in.relStrength(heating_result["T_wall_inner"][i]) * mat_in.sigma_y
 
             # Compute wall temperature gradient
             wall_deltaT = wall_deltaT[::-1]
-        # Makes the data order match with the coolant flow direction, i.e. nozzle exit to injector face
-        # Spent an hour wondering why the throat was cooler than the chamber wall...
+            # Makes the data order match with the coolant flow direction, i.e. nozzle exit to
+            # injector face. Spent an hour wondering why the throat was cooler than the chamber wall...
 
             for i in range(length):
-            cur_stress = material.k * \
-                wall_deltaT[i] / (2 * material.perf_therm)
+                cur_stress = mat_in.k * \
+                    wall_deltaT[i] / (2 * mat_in.perf_therm)
             # Determine thermal stress using Ref [7], P53:
             # sigma_thermal = E*alpha*q_w*deltaL/(2*(1-v)k_w) =
             # E*alpha*deltaT/2(1-v)

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -1100,7 +1100,7 @@ class Engine:
 
 
     #Adding additional components and specifications to the engine
-    def add_geometry(self, chamber_length, chamber_area, inner_wall_thickness, style="auto", **kwargs):
+    def add_geometry(self, chamber_length, chamber_area, inner_wall_thickness, outer_wall_thickness, style="auto"):
         """Specify extra geometry parameters. Required for running cooling system analyses.
 
         Args:
@@ -1114,7 +1114,7 @@ class Engine:
 
 
         self.geometry = EngineGeometry(self.nozzle, chamber_length, chamber_area, inner_wall_thickness,
-                                       style, outer_wall_thickness = outer_wall_thickness)
+                                       style, outer_wall_thickness)
         self.has_geometry = True
 
     def add_cooling_jacket(self, inner_wall, inlet_T, inlet_p0, coolant_transport, mdot_coolant, xs = [-1000, 1000], configuration = "spiral", **kwargs):

--- a/bamboo/main.py
+++ b/bamboo/main.py
@@ -535,7 +535,7 @@ class EngineGeometry:
         
 
     """
-    def __init__(self, nozzle, chamber_length, chamber_area, inner_wall_thickness, outer_wall_thickness style="auto"):
+    def __init__(self, nozzle, chamber_length, chamber_area, inner_wall_thickness, outer_wall_thickness, style="auto"):
         self.chamber_length = chamber_length
         self.chamber_area = chamber_area
         self.chamber_radius = (chamber_area/np.pi)**0.5 

--- a/bamboo/materials.py
+++ b/bamboo/materials.py
@@ -2,6 +2,7 @@
 
 References:
     - [1] - Physical and Mechanical Properties of Copper and Copper Alloys, M. Li and S. J. Zinkle, https://core.ac.uk/download/pdf/208176021.pdf   \n
+    - [2] - AK Steel 304 / 304L Stainless Steel Product Data Bulletin, https://www.aksteel.com/sites/default/files/2018-01/304304L201706_1.pdf   \n
 """
 
 import bamboo.cooling as cool
@@ -16,11 +17,17 @@ import bamboo.cooling as cool
 # Potentially, the inner liner could yield unexpectedly due to the strength decreasing below the
 # maximum transient / thermal stress, so plastic deformation can then occur with further thermal cycles.
 
+# Ref [1]
 CuNiBe_coeffs = [7.71428267e-01,  2.32661906e-03, -8.37447441e-06,  1.38968730e-08, -1.29732074e-11,  4.69949744e-15]
 CuNiBe_config = [273.15, 873.15, 6] # Absolute start and end temps, number of coefficients provided above
 # Coefficients are given in ascending power order: constant, x, x**2, ...
 # Temperatures used with this polynomial must be in Kelvin
 
+# Ref [2]
+Steel304_coeffs = [4.11044348e+01, -4.31300681e-01,  1.84371948e-03, -3.89169923e-06,  3.68275665e-09,
+                   2.86934185e-13, -3.80214923e-15,  3.10261448e-18, -8.31599675e-22]
+Steel304_config = [273.15, 1033.15, 9]
+
 CopperC700 = cool.Material(E = 140e9, sigma_y = 600e6, poisson = 0.355, alpha = 17.5e-6, k = 211, c = 385, rho = 8940, Tsigma_coeffs = CuNiBe_coeffs, Tsigma_range = CuNiBe_config)
 Graphite = cool.Material(E = float('NaN'), sigma_y = float('NaN'), poisson = float('NaN'), alpha = float('NaN'), k = 63.81001, c = 0.720)
-StainlessSteel304 = cool.Material(E = 193e9, sigma_y = 205e6, poisson = float('NaN'), alpha = float('NaN'), k = 16.2, c = 500, rho = float('NaN'))
+StainlessSteel304 = cool.Material(E = 193e9, sigma_y = 241e6, poisson = 0.29, alpha = 16e-6, k = 14, c = 500, rho = 8000, Tsigma_coeffs = Steel304_coeffs, Tsigma_range = Steel304_config)

--- a/bamboo/plot.py
+++ b/bamboo/plot.py
@@ -3,6 +3,8 @@
 
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
+from matplotlib.collections import LineCollection
+from matplotlib.colors import ListedColormap, BoundaryNorm, LinearSegmentedColormap
 import numpy as np
 
 def plot_temperatures(data_dict, **kwargs):

--- a/examples/pressure_example.py
+++ b/examples/pressure_example.py
@@ -12,7 +12,8 @@ import time
 '''Engine dimensions'''
 Ac = np.pi*0.1**2               #Chamber cross-sectional area (m^2)
 L_star = 1.5                    #L_star = Volume_c/Area_t
-wall_thickness = 2e-3
+inner_wall_thickness = 2e-3
+outer_wall_thickness = 5e-3
 
 '''Chamber conditions'''
 pc = 15e5               #Chamber pressure (Pa)
@@ -25,7 +26,8 @@ OF_ratio = 3.5          #Oxidiser/fuel mass ratio
 water_mass_fraction = 0.10  #Fraction of the fuel that is water, by mass
 
 '''Coolant jacket'''
-wall_material = bam.materials.CopperC700
+inner_wall_material = bam.materials.CopperC700
+outer_wall_material = bam.materials.StainlessSteel304
 mdot_coolant = mdot/(OF_ratio + 1) 
 semi_circle_diameter = 0.02
 inlet_T = 298.15                    #Coolant inlet temperature
@@ -68,13 +70,16 @@ print(f"Sea level thrust = {white_dwarf.thrust(1e5)/1000} kN")
 print(f"Sea level Isp = {white_dwarf.isp(1e5)} s")
 
 '''Cooling system setup'''
-cooling_jacket = cool.CoolingJacket(wall_material, inlet_T, pt, coolant_transport, mdot_coolant, channel_shape = "semi-circle", circle_diameter = semi_circle_diameter)
-engine_geometry = cool.EngineGeometry(nozzle, chamber_length, Ac, wall_thickness)
-cooled_engine = cool.EngineWithCooling(chamber, engine_geometry, cooling_jacket, perfect_gas, gas_transport)
+white_dwarf.add_geometry(chamber_length, Ac, inner_wall_thickness, outer_wall_thickness)
+white_dwarf.add_exhaust_transport(gas_transport)
+white_dwarf.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, pt, coolant_transport, mdot_coolant,
+                          configuration = "vertical", channel_height = 0.001, xs = [-100, 100], blockage_ratio = 0.5)
+#white_dwarf.add_cooling_jacket(inner_wall_material, outer_wall_material inlet_T, p_tank, coolant_transport, mdot_coolant,
+#                          configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
 
 '''Run the cooling system simulation, calculate coolant channel length'''
-cooling_data = cooled_engine.run_heating_analysis(number_of_points = 1000, h_gas_model = "3", to_json = "data/heating_output.json")
-channel_length = cooled_engine.channel_geometry(number_of_sections = 1000)
+cooling_data = white_dwarf.steady_heating_analysis(to_json = "data/heating_output.json")
+channel_length = white_dwarf.channel_geometry(number_of_sections = 1000)
 
 '''Plot g raph'''
 fig, axs = plt.subplots()

--- a/examples/regen_ablative_example.py
+++ b/examples/regen_ablative_example.py
@@ -63,7 +63,7 @@ engine.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_t
 #bam.plot.plot_temperatures(data)
 
 '''Run a second simulation with an ablative added'''
-#Add a graphite refractory, and override the copper cooling jacket with a stainless steel layer.
+#Add a graphite refractory
 engine.add_ablative(bam.materials.Graphite, inner_wall_material, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
 
 print(nozzle)

--- a/examples/regen_ablative_example.py
+++ b/examples/regen_ablative_example.py
@@ -64,7 +64,7 @@ engine.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_t
 
 '''Run a second simulation with an ablative added'''
 #Add a graphite refractory, and override the copper cooling jacket with a stainless steel layer.
-engine.add_ablative(bam.materials.Graphite, bam.materials.StainlessSteel304, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
+engine.add_ablative(bam.materials.Graphite, inner_wall_material, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
 
 print(nozzle)
 

--- a/examples/regen_ablative_example.py
+++ b/examples/regen_ablative_example.py
@@ -20,7 +20,7 @@ molecular_weight = 21.627   #Molecular weight of the exhaust gas (kg/kmol) (only
 '''Engine operating points'''
 p_tank = 25e5       #Tank / inlet coolant stagnation pressure (Pa) - used for cooling jacket
 pc = 10e5           #Chamber pressure (Pa)
-Tc = 2800.0           #Chamber temperature (K) - obtained from ProPEP 3
+Tc = 2800.0         #Chamber temperature (K) - obtained from ProPEP 3
 mdot = 4.757        #Mass flow rate (kg/s)
 p_amb = 1.01325e5   #Ambient pressure (Pa). 1.01325e5 is sea level atmospheric.
 OF_ratio = 3.5      #Oxidiser/fuel mass ratio
@@ -28,10 +28,12 @@ OF_ratio = 3.5      #Oxidiser/fuel mass ratio
 '''Engine geometry'''
 Ac = np.pi*0.1**2               #Chamber cross-sectional area (m^2)
 L_star = 1.5                    #L_star = Volume_c/Area_t
-wall_thickness = 2e-3
+inner_wall_thickness = 2e-3
+outer_wall_thickness = 5e-3
 
 '''Coolant jacket'''
-wall_material = bam.materials.CopperC700
+inner_wall_material = bam.materials.CopperC700
+outer_wall_material = bam.materials.StainlessSteel304
 mdot_coolant = mdot/(OF_ratio + 1) 
 inlet_T = 298.15                    #Coolant inlet temperature
 thermo_coolant = thermo.chemical.Chemical('isopropanol')
@@ -49,10 +51,12 @@ thermo_gas = thermo.mixture.Mixture(['N2', 'H2O', 'CO2'], ws = [0.49471, 0.14916
 gas_transport = cool.TransportProperties(model = "thermo", thermo_object = thermo_gas, force_phase = 'g')
 
 '''Cooling system setup'''
-engine.add_geometry(chamber_length, Ac, wall_thickness)
+engine.add_geometry(chamber_length, Ac, inner_wall_thickness, outer_wall_thickness)
 engine.add_exhaust_transport(gas_transport)
-#engine.add_cooling_jacket(wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant, configuration = "vertical", channel_height = 0.001, xs = [-100, 100])
-engine.add_cooling_jacket(wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant, configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
+engine.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant,
+                          configuration = "vertical", channel_height = 0.001, xs = [-100, 100], blockage_ratio = 0.5)
+#engine.add_cooling_jacket(inner_wall_material, outer_wall_material inlet_T, p_tank, coolant_transport, mdot_coolant,
+#                          configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
 
 '''Run a steady state simulation'''
 #data = engine.steady_heating_analysis()

--- a/examples/regen_example.py
+++ b/examples/regen_example.py
@@ -12,7 +12,8 @@ import time
 '''Engine dimensions'''
 Ac = np.pi*0.1**2               #Chamber cross-sectional area (m^2)
 L_star = 1.5                    #L_star = Volume_c/Area_t
-wall_thickness = 2e-3
+inner_wall_thickness = 2e-3
+outer_wall_thickness = 5e-3
 
 '''Chamber conditions'''
 pc = 15e5               #Chamber pressure (Pa)
@@ -25,7 +26,8 @@ OF_ratio = 3.5          #Oxidiser/fuel mass ratio
 water_mass_fraction = 0.10  #Fraction of the fuel that is water, by mass
 
 '''Coolant jacket'''
-wall_material = bam.materials.CopperC700
+inner_wall_material = bam.materials.CopperC700
+outer_wall_material = bam.materials.StainlessSteel304
 mdot_coolant = mdot/(OF_ratio + 1) 
 inlet_T = 298.15                    #Coolant inlet temperature
 
@@ -67,16 +69,13 @@ white_dwarf = bam.Engine(perfect_gas, chamber_conditions, nozzle)
 chamber_length = L_star*nozzle.At/Ac
 
 '''Add the cooling system to the engine'''
-white_dwarf.add_geometry(chamber_length, Ac, wall_thickness)
+white_dwarf.add_geometry(chamber_length, Ac, inner_wall_thickness, outer_wall_thickness)
 white_dwarf.add_exhaust_transport(gas_transport)
 
-#Spiral channels
-#white_dwarf.add_cooling_jacket(wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant, 
-#                               configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
-
-#Or vertical channels
-white_dwarf.add_cooling_jacket(wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant, 
-                               configuration = "vertical", channel_height = 0.001)
+white_dwarf.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant,
+                          configuration = "vertical", channel_height = 0.001, xs = [-100, 100], blockage_ratio = 0.5)
+#white_dwarf.add_cooling_jacket(inner_wall_material, outer_wall_material inlet_T, p_tank, coolant_transport, mdot_coolant,
+#                          configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
 
 '''Run the heating analysis'''
 print(f"Sea level thrust = {white_dwarf.thrust(1e5)/1000} kN")

--- a/examples/stress_example.py
+++ b/examples/stress_example.py
@@ -59,9 +59,9 @@ engine.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_t
 engine.add_ablative(bam.materials.Graphite, bam.materials.StainlessSteel304, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
 
 print(f"Sea level thrust = {engine.thrust(1e5)/1000} kN")
-print(f"Sea level Isp = {engine.isp(1e5)} s")     
+print(f"Sea level Isp = {engine.isp(1e5)} s")
 
-num_pts = 100 # Only increased beyond 1000 to make the graph smoother, no meaningful accuracy gain
+num_pts = 2000 # Only increased beyond 1000 to make the graph smoother, no meaningful accuracy gain
 cooling_data = engine.steady_heating_analysis(number_of_points=num_pts, to_json = "data/heating_output.json")
 
 '''Run the stress analysis, using cooling simulation data'''
@@ -153,11 +153,9 @@ ax_s.axvline(shape_x[max_stress_index], color = 'red', linestyle = '--',
                      f"""$\sigma = $ {stress_data["thermal_stress"][max_stress_index]/10**6:.2f} $MPa$,"""
                      f""" $\sigma_y = $ {yield_max_rel/10**6:.2f} $MPa$""")
 
-plt.figtext(0.5, 0.12, "(Ablator / refractory not currently shown, if present)", ha="center", fontsize=10)
-
 ax_s.set_xlabel("Axial displacement from throat / $m$")
 ax_s.set_ylabel("Radial position / $m$")
 plt.gca().set_aspect('equal', adjustable='box')
-# Equal axes scales for a true view of the engine
+# Equal axis scales for a true view of the engine
 ax_s.legend()
 plt.show()

--- a/examples/stress_example.py
+++ b/examples/stress_example.py
@@ -55,8 +55,8 @@ engine.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_t
 #                          configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
 
 '''Run a second simulation with an ablative added'''
-#Add a graphite refractory, and override the copper cooling jacket with a stainless steel layer.
-engine.add_ablative(bam.materials.Graphite, bam.materials.StainlessSteel304, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
+#Add a graphite refractory.
+engine.add_ablative(bam.materials.Graphite, inner_wall_material, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
 
 print(f"Sea level thrust = {engine.thrust(1e5)/1000} kN")
 print(f"Sea level Isp = {engine.isp(1e5)} s")
@@ -64,12 +64,11 @@ print(f"Sea level Isp = {engine.isp(1e5)} s")
 num_pts = 2000 # Only increased beyond 1000 to make the graph smoother, no meaningful accuracy gain
 cooling_data = engine.steady_heating_analysis(number_of_points=num_pts, to_json = "data/heating_output.json")
 
-'''Run the stress analysis, using cooling simulation data'''
-stress_data = engine.run_stress_analysis(heating_result=cooling_data, mode="thermal", condition="steady")
-max_rel_stress = np.amax(stress_data["thermal_stress"]/stress_data["tadjusted_yield"])
-min_rel_stress = np.amin(stress_data["thermal_stress"]/stress_data["tadjusted_yield"])
 
-'''Get nozzle data, including the ablator if it is present'''
+'''Run a transient stress analysis, using cooling simulation data'''
+transient_stress = engine.run_stress_analysis(heating_result=cooling_data, condition="transient")
+
+'''Get nozzle data, including the ablator if it is present, set up transient and steady state figures'''
 shape_x = np.linspace(engine.geometry.x_min, engine.geometry.x_max, num_pts)
 shape_y = np.zeros(len(shape_x))
 fig2, ax_s = plt.subplots()
@@ -80,12 +79,13 @@ ablative_inner = np.zeros(num_pts)
 ablative_outer = np.zeros(num_pts)
 
 if engine.has_ablative is True:
-    for i in range(len(shape_x)):
-        shape_y[i] = engine.geometry.chamber_radius
-        ablative_inner[i] = engine.y(x[i], up_to = 'ablative in') - 0.0085 # The -0.0085 corrects for the line width
-        ablative_outer[i] = engine.y(x[i], up_to = 'ablative out') - 0.0085 # The -0.0085 corrects for the line width
-    ax_s.fill_between(x, ablative_inner, ablative_outer, color="grey", label = 'Ablative')
-    ax_s.fill_between(x, -ablative_inner, -ablative_outer, color="grey")   
+    for axes in [ax_s]: # Can add to this if more figures with colour maps are added
+        for i in range(len(shape_x)):
+            shape_y[i] = engine.geometry.chamber_radius
+            ablative_inner[i] = engine.y(x[i], up_to = 'ablative in') - 0.0085 # The -0.0085 corrects for the line width
+            ablative_outer[i] = engine.y(x[i], up_to = 'ablative out') - 0.0085 # The -0.0085 corrects for the line width
+        axes.fill_between(x, ablative_inner, ablative_outer, color="grey", label = 'Ablative')
+        axes.fill_between(x, -ablative_inner, -ablative_outer, color="grey")   
 else:
     for i in range(len(shape_x)):
         shape_y[i] = engine.y(shape_x[i])
@@ -97,38 +97,34 @@ segments1 = np.concatenate([points1[:-1], points1[1:]], axis=1)
 segments2 = np.concatenate([points2[:-1], points2[1:]], axis=1)
 # Each element in segments represents a point defining a coloured line segment
 
-norm_max = max_rel_stress
-if max_rel_stress < np.amax(stress_data["tadjusted_yield"]):
-    mid = 1.0
-    red_max = 0.0
+'''Run the steady state stress analysis, using cooling simulation data'''
+steady_stress = engine.run_stress_analysis(heating_result=cooling_data, condition="steady")
+rel_stress = steady_stress["thermal_stress"]/steady_stress["tadjusted_yield"]
+max_rel_stress = np.amax(rel_stress)
+min_rel_stress = np.amin(rel_stress)
+
+if max_rel_stress < 1:
+    cdict = {"red":  [(0, 0, 0), (0, 0, 0), (1, 0, 0)],
+            "green": [(0, 1, 1), (0.7, 0, 0), (1, 0, 0)],
+            "blue":  [(0, 0, 0), (0.5, 0, 0), (1, 1, 1)]}
 else:
-    mid = engine.cooling_jacket.inner_wall.sigma_y/max_stress
-    red_max = 1.0
-# Check if yield is reached to adjust colour mapping, normalisation
-   
-cdict = {"red":  [(0.0, 0.0, 0.0),
-                  (mid, 0.0, 0.0),
-                  (1.0, red_max, red_max)],  
-    
-        "green": [(0.0, 1.0, 1.0),
-                  (mid/2, 0.0, 0.0),
-                  (1.0, 0.0, 0.0)],
-         
-        "blue":  [(0.0, 0.0, 0.0),
-                  (mid/2, 0.0, 0.0),
-                  (mid, 1.0, 1.0),
-                  (1.0, 0.0, 0.0)]}
+    cdict = {"red":   [(0, 0, 0), (1/(1.1*raw_max), 0, 0), 
+                       (1/(raw_max), 1, 1), (1, 1, 1)],
+             "green": [(0, 1, 1), (1/(2*raw_max), 0, 0), (1, 0, 0)],
+             "blue":  [(0, 0, 0), (1/(2*raw_max), 0, 0),
+                       (1/max_rel_stress, 0.4, 0.4), (1, 0, 0)]}  
+
 colours = LinearSegmentedColormap("colours", cdict)
 # Set up colour map for stress values
 
-norm = plt.Normalize(np.amin(stress_data["thermal_stress"]/min_rel_stress), norm_max)
+norm = plt.Normalize(0, max_rel_stress)
 # Normalise the stress data so it can be mapped
 
 lc1 = LineCollection(segments1, cmap=colours, norm=norm)
-lc1.set_array(stress_data["thermal_stress"])
+lc1.set_array(rel_stress)
 lc1.set_linewidth(40)
 lc2 = LineCollection(segments2, cmap=colours, norm=norm)
-lc2.set_array(stress_data["thermal_stress"])
+lc2.set_array(rel_stress)
 lc2.set_linewidth(40)
 # Create line collections defined by segments arrays, map colours
 
@@ -136,26 +132,25 @@ line1 = ax_s.add_collection(lc1)
 line2 = ax_s.add_collection(lc2)
 
 cbar = fig2.colorbar(line1, ax=ax_s)
-cbar.set_label("$\sigma$ / $Pa$")
+cbar.set_label("Relative stress, $\sigma / \sigma_{ya}$")
 #cbar = fig2.colorbar(line1, ax=ax_s, ticks=[int(engine.cooling_jacket.inner_wall.sigma_y)])
 #cbar.set_ticklabels(["$\sigma_y$"])
 
 ax_s.set_xlim(shape_x.min(), shape_x.max())
 ax_s.set_ylim(-shape_y.max(), shape_y.max())
 
-max_stress_index = np.where(stress_data["thermal_stress"]/stress_data["tadjusted_yield"] == max_rel_stress)[0][0]
+max_stress_index = np.where(rel_stress == max_rel_stress)[0][0]
 # Position of the maximum relative stress given as the index of the corresponding x position from heating analysis
-yield_max_rel = stress_data["tadjusted_yield"][max_stress_index]
-# The local temperature adjusted yield stress at the location of the highest relative stress
 
 ax_s.axvline(shape_x[max_stress_index], color = 'red', linestyle = '--',
              label = f"""Max relative stress {100*max_rel_stress:.2f}% where """
-                     f"""$\sigma = $ {stress_data["thermal_stress"][max_stress_index]/10**6:.2f} $MPa$,"""
-                     f""" $\sigma_y = $ {yield_max_rel/10**6:.2f} $MPa$""")
+                     f"""$\sigma = ${steady_stress["thermal_stress"][max_stress_index]/10**6:.2f} $MPa$,"""
+                     f""" $\sigma_{{ya}} = $ {steady_stress["tadjusted_yield"][max_stress_index]/10**6:.2f} $MPa$""")
 
 ax_s.set_xlabel("Axial displacement from throat / $m$")
 ax_s.set_ylabel("Radial position / $m$")
-plt.gca().set_aspect('equal', adjustable='box')
+ax_s.set_title("Steady state thermal stress")
+ax_s.set_aspect('equal', adjustable='box')
 # Equal axis scales for a true view of the engine
 ax_s.legend()
 plt.show()

--- a/examples/stress_example_legacy.py
+++ b/examples/stress_example_legacy.py
@@ -1,0 +1,161 @@
+import bamboo as bam
+import bamboo.cooling as cool
+import bamboo.materials
+
+import numpy as np
+import pypropep as ppp
+import thermo
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+from matplotlib.colors import ListedColormap, BoundaryNorm, LinearSegmentedColormap
+
+"""With recent changes to the stress analysis methods and more complexity in how materials
+are handled (temperature compensated yield stress), it's clearer to present stress
+analysis results with conventional plots. This may be removed, with the graphing section
+added to bamboo/plot.py"""
+
+'''Gas properties - obtained from ProPEP 3'''
+gamma = 1.264               #Ratio of specific heats cp/cv
+molecular_weight = 21.627   #Molecular weight of the exhaust gas (kg/kmol) (only used to calculate R, and hence cp)
+
+'''Engine operating points'''
+p_tank = 25e5       #Tank / inlet coolant stagnation pressure (Pa) - used for cooling jacket
+pc = 10e5           #Chamber pressure (Pa)
+Tc = 2800.0         #Chamber temperature (K) - obtained from ProPEP 3
+mdot = 4.757        #Mass flow rate (kg/s)
+p_amb = 1.01325e5   #Ambient pressure (Pa). 1.01325e5 is sea level atmospheric.
+OF_ratio = 3.5      #Oxidiser/fuel mass ratio
+
+'''Engine geometry'''
+Ac = np.pi*0.1**2               #Chamber cross-sectional area (m^2)
+L_star = 1.5                    #L_star = Volume_c/Area_t
+inner_wall_thickness = 2e-3
+outer_wall_thickness = 5e-3
+
+'''Coolant jacket'''
+inner_wall_material = bam.materials.CopperC700
+outer_wall_material = bam.materials.StainlessSteel304
+mdot_coolant = mdot/(OF_ratio + 1) 
+inlet_T = 298.15                    #Coolant inlet temperature
+thermo_coolant = thermo.chemical.Chemical('isopropanol')
+coolant_transport = cool.TransportProperties(model = "thermo", thermo_object = thermo_coolant, force_phase = 'l')
+
+'''Create the engine object'''
+perfect_gas = bam.PerfectGas(gamma = gamma, molecular_weight = molecular_weight)
+chamber = bam.ChamberConditions(pc, Tc, mdot)
+nozzle = bam.Nozzle.from_engine_components(perfect_gas, chamber, p_amb, type = "rao", length_fraction = 0.8)
+engine = bam.Engine(perfect_gas, chamber, nozzle)
+chamber_length = L_star*nozzle.At/Ac
+
+'''Choose the models we want to use for transport properties of the exhaust gas'''
+thermo_gas = thermo.mixture.Mixture(['N2', 'H2O', 'CO2'], ws = [0.49471, 0.14916, 0.07844])            #Very crude exhaust gas model - using weight fractions from CEA.
+gas_transport = cool.TransportProperties(model = "thermo", thermo_object = thermo_gas, force_phase = 'g')
+
+'''Cooling system setup'''
+engine.add_geometry(chamber_length, Ac, inner_wall_thickness, outer_wall_thickness, style="auto")
+engine.add_exhaust_transport(gas_transport)
+engine.add_cooling_jacket(inner_wall_material, outer_wall_material, inlet_T, p_tank, coolant_transport, mdot_coolant,
+                          configuration = "vertical", channel_height = 0.001, xs = [-100, 100], blockage_ratio = 0.5)
+#engine.add_cooling_jacket(inner_wall_material, outer_wall_material inlet_T, p_tank, coolant_transport, mdot_coolant,
+#                          configuration = "spiral", channel_shape = "semi-circle", channel_width = 0.020)
+
+'''Run a second simulation with an ablative added'''
+#Add a graphite refractory.
+engine.add_ablative(bam.materials.Graphite, inner_wall_material, regression_rate = 0.0033e-3, xs = [engine.geometry.x_chamber_end, 100], ablative_thickness = None)
+
+print(f"Sea level thrust = {engine.thrust(1e5)/1000} kN")
+print(f"Sea level Isp = {engine.isp(1e5)} s")
+
+num_pts = 2000 # Only increased beyond 1000 to make the graph smoother, no meaningful accuracy gain
+cooling_data = engine.steady_heating_analysis(number_of_points=num_pts, to_json = "data/heating_output.json")
+
+
+'''Run a transient stress analysis, using cooling simulation data'''
+transient_stress = engine.run_stress_analysis(heating_result=cooling_data, condition="transient")
+
+'''Get nozzle data, including the ablator if it is present, set up transient and steady state figures'''
+shape_x = np.linspace(engine.geometry.x_min, engine.geometry.x_max, num_pts)
+shape_y = np.zeros(len(shape_x))
+fig2, ax_s = plt.subplots()
+
+# Code here involving the ablator is ripped out of Engine.plot_geometry()
+x = np.linspace(engine.geometry.x_min, engine.geometry.x_max, num_pts)
+ablative_inner = np.zeros(num_pts)
+ablative_outer = np.zeros(num_pts)
+
+if engine.has_ablative is True:
+    for axes in [ax_s]: # Can add to this if more figures with colour maps are added
+        for i in range(len(shape_x)):
+            shape_y[i] = engine.geometry.chamber_radius
+            ablative_inner[i] = engine.y(x[i], up_to = 'ablative in') - 0.0085 # The -0.0085 corrects for the line width
+            ablative_outer[i] = engine.y(x[i], up_to = 'ablative out') - 0.0085 # The -0.0085 corrects for the line width
+        axes.fill_between(x, ablative_inner, ablative_outer, color="grey", label = 'Ablative')
+        axes.fill_between(x, -ablative_inner, -ablative_outer, color="grey")   
+else:
+    for i in range(len(shape_x)):
+        shape_y[i] = engine.y(shape_x[i])
+
+'''Plot results'''
+points1 = np.array([shape_x, shape_y]).T.reshape(-1, 1, 2)
+points2 = np.array([shape_x, -shape_y]).T.reshape(-1, 1, 2)
+segments1 = np.concatenate([points1[:-1], points1[1:]], axis=1)
+segments2 = np.concatenate([points2[:-1], points2[1:]], axis=1)
+# Each element in segments represents a point defining a coloured line segment
+
+'''Run the steady state stress analysis, using cooling simulation data'''
+steady_stress = engine.run_stress_analysis(heating_result=cooling_data, condition="steady")
+rel_stress = steady_stress["thermal_stress"]/steady_stress["yield_adj"]
+max_rel_stress = np.amax(rel_stress)
+min_rel_stress = np.amin(rel_stress)
+
+if max_rel_stress < 1:
+    cdict = {"red":  [(0, 0, 0), (0, 0, 0), (1, 0, 0)],
+            "green": [(0, 1, 1), (0.7, 0, 0), (1, 0, 0)],
+            "blue":  [(0, 0, 0), (0.5, 0, 0), (1, 1, 1)]}
+else:
+    cdict = {"red":   [(0, 0, 0), (1/(1.1*raw_max), 0, 0), 
+                       (1/(raw_max), 1, 1), (1, 1, 1)],
+             "green": [(0, 1, 1), (1/(2*raw_max), 0, 0), (1, 0, 0)],
+             "blue":  [(0, 0, 0), (1/(2*raw_max), 0, 0),
+                       (1/max_rel_stress, 0.4, 0.4), (1, 0, 0)]}  
+
+colours = LinearSegmentedColormap("colours", cdict)
+# Set up colour map for stress values
+
+norm = plt.Normalize(0, max_rel_stress)
+# Normalise the stress data so it can be mapped
+
+lc1 = LineCollection(segments1, cmap=colours, norm=norm)
+lc1.set_array(rel_stress)
+lc1.set_linewidth(40)
+lc2 = LineCollection(segments2, cmap=colours, norm=norm)
+lc2.set_array(rel_stress)
+lc2.set_linewidth(40)
+# Create line collections defined by segments arrays, map colours
+
+line1 = ax_s.add_collection(lc1)
+line2 = ax_s.add_collection(lc2)
+
+cbar = fig2.colorbar(line1, ax=ax_s)
+cbar.set_label("Relative stress, $\sigma / \sigma_{ya}$")
+#cbar = fig2.colorbar(line1, ax=ax_s, ticks=[int(engine.cooling_jacket.inner_wall.sigma_y)])
+#cbar.set_ticklabels(["$\sigma_y$"])
+
+ax_s.set_xlim(shape_x.min(), shape_x.max())
+ax_s.set_ylim(-shape_y.max(), shape_y.max())
+
+max_stress_index = np.where(rel_stress == max_rel_stress)[0][0]
+# Position of the maximum relative stress given as the index of the corresponding x position from heating analysis
+
+ax_s.axvline(shape_x[max_stress_index], color = 'red', linestyle = '--',
+             label = f"""Max relative stress {100*max_rel_stress:.2f}% where """
+                     f"""$\sigma = ${steady_stress["thermal_stress"][max_stress_index]/10**6:.2f} $MPa$,"""
+                     f""" $\sigma_{{ya}} = $ {steady_stress["yield_adj"][max_stress_index]/10**6:.2f} $MPa$""")
+
+ax_s.set_xlabel("Axial displacement from throat / $m$")
+ax_s.set_ylabel("Radial position / $m$")
+ax_s.set_title("Steady state thermal stress")
+ax_s.set_aspect('equal', adjustable='box')
+# Equal axis scales for a true view of the engine
+ax_s.legend()
+plt.show()

--- a/stress_example.py
+++ b/stress_example.py
@@ -87,15 +87,9 @@ axs1_2.legend(bbox_to_anchor = (0, -0.22), loc = "lower left")
 
 fig1.subplots_adjust(bottom = 0.16)
 
-axs2.plot(xs, steady_stress["stress_inner_hoop_steady"]/1E6, label="Inner liner, prior to ignition")
-axs2.plot(xs, transient_stress["stress_inner_hoop_transient"]/1E6, label="Inner liner, after ignition")
-axs2.plot(xs, steady_stress["stress_outer_hoop"]/1E6, label="Outer liner")
+axs2.plot(xs, steady_stress["stress_inner_hoop_steady"], label="Inner liner, prior to ignition")
+axs2.plot(xs, transient_stress["stress_inner_hoop_II"], label="Inner liner, after ignition")
+axs2.plot(xs, steady_stress["stress_outer_hoop"], label="Outer liner")
 axs2.set_title("Hoop stresses in liners")
-axs2.set_xlabel("Axial displacement from throat $(m)$")
-axs2.set_ylabel("Stress $(MPa)$")
-axs2.set_ylim([0, None])
-axs2.legend(bbox_to_anchor = (0, -0.19), loc = "lower left")
-
-fig2.subplots_adjust(bottom = 0.14)
 
 plt.show()


### PR DESCRIPTION
There are some other changes besides the additions to the `Engine.run_stress_analysis()` method:

- Blockage ratio for vertical channels (the fraction of the coolant channel cross-sectional area taken up by the ribs / cage, currently does not impact heat transfer),
- Requirement for the outer liner to be specified for `CoolingJacket` objects (relevant examples have been updated to work)
- Support for variable outer liner thickness, as with inner liner thickness
- Temp / yield data for 304 steel
- Rewritten `stress_example.py` to be clearer - the old way of presenting the result with a colourmap is no longer sufficient at presenting all of the relevant data